### PR TITLE
Re-factored way the HTTP configs are stored and retrieved (trying to debug but also simplified)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ VuexORM.use(VuexORMAxios, {
       'Accept': 'application/json',
       'Content-Type': 'application/json'
     }
+  },
+  // Include an HTTPConf for each entity
+  modelHttpConfigs: {
+    'todo': TodoHTTPConf
   }
 })
 ..
@@ -29,6 +33,46 @@ export default () => new Vuex.Store({
 })
 
 ```
+
+### HTTPConf (for each model)
+``` js
+export const TodoHTTPConf = {
+  http: {
+    url: '/batch'
+  },
+  methods: {
+    $fetch: {
+      name: 'fetch',
+      http: {
+        url: '',
+        method: 'get'
+      }
+    },
+    $get: {
+      name: 'get',
+      http: {
+        url: '/:id',
+        method: 'get',
+      },
+    },
+    $update: {
+      name: 'update',
+      http: {
+        url: '/:id/mark/',
+        method: 'put'
+      }
+    },
+    $delete: {
+      name: 'delete',
+      http: {
+        url: '/:id',
+        method: 'delete'
+      }
+    }
+  }
+}
+```
+
 
 # Axios Request Config
 
@@ -203,7 +247,7 @@ User.$get({
   params: {
     id: 1
   }
-}); 
+});
 
 /**
  * @uri `/users`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2844,6 +2844,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+      "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow=="
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@vuex-orm/core": "^0.26.2",
+    "deepmerge": "^3.2.0",
     "lodash-es": "^4.17.11"
   },
   "devDependencies": {

--- a/src/actions/Fetch.js
+++ b/src/actions/Fetch.js
@@ -1,6 +1,8 @@
+import * as deepmerge from 'deepmerge'
 import Axios from '../orm/axios'
 import Context from '../common/context'
 import Action from './Action'
+import { ModelConfig } from '../support/interfaces'
 
 export default class Fetch extends Action {
   /**
@@ -11,12 +13,22 @@ export default class Fetch extends Action {
   static async call({ state, commit }, params = {}) {
     const context = Context.getInstance()
     const model = context.getModelFromState(state)
-    const endpoint = Action.transformParams('$fetch', model, params)
-    const axios = new Axios(model.methodConf.http)
+    // Merge default http settings
+    ModelConfig.http = deepmerge.all([{}, ModelConfig.http, context.options.http])
+
+    // Get HTTPConf for this model
+    const HttpConf = context.getHttpConfigForModel(model.entity)
+    const endpoint = Action.transformParams('$fetch', HttpConf, params)
+
+    // New axios instance (with settings)
+    const axios = new Axios(ModelConfig.http)
     const request = axios.get(endpoint)
 
     this.onRequest(commit)
-    request.then(data => this.onSuccess(commit, model, data)).catch(error => this.onError(commit, error))
+
+    request
+      .then(data => this.onSuccess(commit, model, data))
+      .catch(error => this.onError(commit, error))
 
     return request
   }
@@ -31,15 +43,15 @@ export default class Fetch extends Action {
 
   /**
    * On Successful Request Method
+   * NOTE: At this point the `data` property is just the raw response from the
+   * server (other axios response properties have been stripped).
    * @param {object} commit
    * @param {object} model
    * @param {object} data
    */
   static onSuccess(commit, model, data) {
     commit('onSuccess')
-    model.insertOrUpdate({
-      data,
-    })
+    model.insertOrUpdate({data})
   }
 
   /**

--- a/src/actions/Get.js
+++ b/src/actions/Get.js
@@ -1,6 +1,8 @@
+import * as deepmerge from 'deepmerge'
 import Axios from '../orm/axios'
 import Context from '../common/context'
 import Action from './Action'
+import { ModelConfig } from '../support/interfaces'
 
 export default class Get extends Action {
   /**
@@ -11,12 +13,22 @@ export default class Get extends Action {
   static async call({ state, commit }, params = {}) {
     const context = Context.getInstance()
     const model = context.getModelFromState(state)
-    const endpoint = Action.transformParams('$get', model, params)
-    const axios = new Axios(model.methodConf.http)
+    // Merge default http settings
+    ModelConfig.http = deepmerge.all([{}, ModelConfig.http, context.options.http])
+
+    // Get HTTPConf for this model
+    const HttpConf = context.getHttpConfigForModel(model.entity)
+    const endpoint = Action.transformParams('$get', HttpConf, params)
+
+    // New axios instance (with settings)
+    const axios = new Axios(ModelConfig.http)
     const request = axios.get(endpoint)
 
     this.onRequest(commit)
-    request.then(data => this.onSuccess(commit, model, data)).catch(error => this.onError(commit, error))
+
+    request
+      .then(data => this.onSuccess(commit, model, data))
+      .catch(error => this.onError(commit, error))
 
     return request
   }
@@ -31,15 +43,15 @@ export default class Get extends Action {
 
   /**
    * On Successful Request Method
+   * NOTE: At this point the `data` property is just the raw response from the
+   * server (other axios response properties have been stripped).
    * @param {object} commit
    * @param {object} model
    * @param {object} data
    */
   static onSuccess(commit, model, data) {
     commit('onSuccess')
-    model.insertOrUpdate({
-      data,
-    })
+    model.insertOrUpdate({data})
   }
 
   /**

--- a/src/common/context.js
+++ b/src/common/context.js
@@ -1,4 +1,5 @@
-import merge from 'lodash-es/merge'
+// import merge from 'lodash-es/merge'
+import * as deepmerge from 'deepmerge'
 import { VuexOrmPluginConfig } from '../support/interfaces'
 
 export default class Context {
@@ -11,8 +12,13 @@ export default class Context {
    */
   constructor(components, options) {
     this.components = components
-    this.options = merge({}, VuexOrmPluginConfig, options)
+    this.options = deepmerge.all([{}, VuexOrmPluginConfig, options])
     this.database = options.database
+
+    if (!options.modelHttpConfigs) {
+      throw new Error('At least one modelHttpConf required')
+    }
+    this.modelHttpConfigs = options.modelHttpConfigs
 
     if (!options.database) {
       throw new Error('database option is required to initialise!')
@@ -44,5 +50,17 @@ export default class Context {
    */
   getModelFromState(state) {
     return this.database.entities.find(({ name }) => name == state.$name).model
+  }
+
+  /**
+   * Returns an HTTPConf object for a given entity name
+   * @param {string} entityName
+   */
+  getHttpConfigForModel(entityName) {
+    if (this.modelHttpConfigs.hasOwnProperty(entityName)) {
+      return this.modelHttpConfigs[entityName]
+    } else {
+      throw new Error(`No HTTPconfig found for entity: ${entityName}`)
+    }
   }
 }

--- a/src/orm/axios.js
+++ b/src/orm/axios.js
@@ -2,19 +2,18 @@ import axios from 'axios'
 
 export default class Axios {
   constructor(http) {
-    this.instance = axios.create(http);
-    this.setAuthentication(http.access_token);
+    this.instance = axios.create(http)
+    this.setAuthentication(http.access_token)
 
     this.instance.interceptors.request.use(
       config => http.onRequest(config),
       error => http.onError(error),
-    );
+    )
 
-
-    this.instance.interceptors.request.use(
-      config => http.onRequest(config),
+    this.instance.interceptors.response.use(
+      config => http.onResponse(config),
       error => http.onError(error),
-    );
+    )
 
     return this.instance;
   }

--- a/src/vuex-orm-axios.js
+++ b/src/vuex-orm-axios.js
@@ -43,7 +43,8 @@ export default class VuexOrmAxios {
      */
     context.database.entities.map(entity => {
       entity.module = Action.transformModule(entity.module)
-      entity.model = Action.transformModel(entity.model)
+      // NOTE: This has been removed because it causes issues (IE11)
+      // entity.model = Action.transformModel(entity.model)
       return entity
     })
 


### PR DESCRIPTION
- Removed `Action.transformModel` call, so HTTP config is no longer stored on the model in the store.
- Instead uses a new object passed in on VuexOrmAxios setup called `modelHttpConfigs`.
- Replaced `lodash.merge` with `deepmerge` package.